### PR TITLE
Fix pagination deprecate and permalink upgrade

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,7 +2,6 @@
 #
 # Use of `relative_permalinks` ensures post links from the index work properly.
 permalink:           pretty
-relative_permalinks: true
 
 # Setup
 title:               Jekyll Marlene
@@ -28,3 +27,6 @@ author:
 version:             1.0.0
 github:
   repo:             https://github.com/filipelinhares/jekyll-marlene
+
+# Gems
+gems:               [jekyll-paginate]


### PR DESCRIPTION
Fix the pagination deprecate problem, adding `gems: [jekyll-paginate]` at `config.yml` and the permalink upgrade by removing the `relative_permalinks: true` at `config.yml` .